### PR TITLE
Fixing the User menu for R-to-L languages

### DIFF
--- a/styles/head.less
+++ b/styles/head.less
@@ -188,4 +188,9 @@
 			color: @text-bg-base;
 		}
 	}
+
+	body[dir="rtl"] #navigationUserWrapper.pkp_navigation_user_wrapper {
+		right: auto;
+		left: 0;
+	}
 }


### PR DESCRIPTION
Adding a rule to adjust the location of the User menu on the top bar. It is currently floating over the Journal title and truncating it. The journal editor can't see it. This patch fixes this issue: https://github.com/pkp/pkp-lib/issues/7733